### PR TITLE
change path to ValidationException to match upstream

### DIFF
--- a/jenkinsBot.py
+++ b/jenkinsBot.py
@@ -8,7 +8,7 @@ from itertools import chain
 from jinja2 import Template
 from jenkins import Jenkins, JenkinsException, LAUNCHER_JNLP
 from errbot import BotPlugin, botcmd, webhook
-from errbot.utils import ValidationException
+from errbot import ValidationException
 
 try:
     from config import JENKINS_URL, JENKINS_USERNAME, JENKINS_PASSWORD


### PR DESCRIPTION
Match upstream errbot changes.

see: https://github.com/errbotio/errbot/blob/master/CHANGES.rst
- utils.ValidationException has moved to errbot.ValidationException and is fully part of the API.

Thx